### PR TITLE
Update target raygun4js version in blueprint

### DIFF
--- a/blueprints/ember-cli-raygun/index.js
+++ b/blueprints/ember-cli-raygun/index.js
@@ -24,7 +24,7 @@ module.exports = {
     var self = this,
       raygunApiKey = options.api_key || 'YOUR-RAYGUN-API-KEY';
 
-    return this.addBowerPackagesToProject([ { name: 'raygun4js', target: "^1.18.4"} ])
+    return this.addBowerPackagesToProject([ { name: 'raygun4js', target: ">2.3.0"} ])
     .then(function() {
       return self.setupRaygunConfig(raygunApiKey);
     })

--- a/blueprints/ember-cli-raygun/index.js
+++ b/blueprints/ember-cli-raygun/index.js
@@ -24,7 +24,7 @@ module.exports = {
     var self = this,
       raygunApiKey = options.api_key || 'YOUR-RAYGUN-API-KEY';
 
-    return this.addBowerPackagesToProject([ { name: 'raygun4js', target: "~2.0.3"} ])
+    return this.addBowerPackagesToProject([ { name: 'raygun4js', target: "^2.2.1"} ])
     .then(function() {
       return self.setupRaygunConfig(raygunApiKey);
     })

--- a/blueprints/ember-cli-raygun/index.js
+++ b/blueprints/ember-cli-raygun/index.js
@@ -24,7 +24,7 @@ module.exports = {
     var self = this,
       raygunApiKey = options.api_key || 'YOUR-RAYGUN-API-KEY';
 
-    return this.addBowerPackagesToProject([ { name: 'raygun4js', target: ">2.3.0"} ])
+    return this.addBowerPackagesToProject([ { name: 'raygun4js', target: "~2.0.3"} ])
     .then(function() {
       return self.setupRaygunConfig(raygunApiKey);
     })


### PR DESCRIPTION
Update the target version of `raygun4js` specified in the `blueprints/ember-cli-raygun/index.js` file.  Will now attempt to use the most recent `raygun4js` version greater that `2.2.1` and less than `3.0.0`.

Previously was targeting anything greater than `1.18.4` and less than `2.0.0` which caused issues with users not having access to methods/changes made in `2.x.x`.